### PR TITLE
Add support for gamepads

### DIFF
--- a/io.github.doukutsu_rs.doukutsu-rs.yaml
+++ b/io.github.doukutsu_rs.doukutsu-rs.yaml
@@ -8,7 +8,7 @@ command: doukutsu-rs
 build-options:
   append-path: /usr/lib/sdk/rust-stable/bin
 finish-args:
-  - --device=dri
+  - --device=all
   - --share=ipc
   - --socket=fallback-x11
   - --socket=pulseaudio


### PR DESCRIPTION
Flathub doesn't currently support `--device=input`(as you can see this in other repositories that have tried to introduce this change), so we have to request access to all devices.

Fixes doukutsu-rs/doukutsu-rs#305.